### PR TITLE
Readonly launch files for rl cruise hybrid, noplanner and planner

### DIFF
--- a/launch/rl_cruise_hybrid_noplanner_readonly.launch
+++ b/launch/rl_cruise_hybrid_noplanner_readonly.launch
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<launch>
+
+	<arg name="description" default="rl_cruise_hybrid_noplanner"/>
+	
+	<arg name="hwil" default="true"/>
+	<arg name="SPACEGAP_SCALE" default="100.0"/>
+	<arg name="SPEED_SCALE" default="40.0"/>
+	<!-- for no planner, set these two to -1 -->
+	<arg name="SP_TARGET_SPEED" default="-1"/>
+	<arg name="SP_MAX_HEADWAY" default="1"/>
+	<arg name='readonly' default='true'/>
+
+	<param name="description" value="$(arg description)"/>
+		
+	<param name="/SPACEGAP_SCALE" value="$(arg SPACEGAP_SCALE)"/>
+	<param name="/SPEED_SCALE" value="$(arg SPEED_SCALE)"/>
+	<param name="/SP_TARGET_SPEED" value="$(arg SP_TARGET_SPEED)"/>
+	<param name="/SP_MAX_HEADWAY" value="$(arg SP_MAX_HEADWAY)"/>
+	
+	<param name="/readonly" value="$(arg readonly)"/>
+	<param name="/hwil" value="$(arg hwil)"/>
+<!--
+	<node pkg="can_to_ros" type ="subs_fs" name="subs_fs" output="screen" if="$(arg hwil)"/> 
+	<node pkg="can_to_ros" type="lead_info" name="lead_info" output="screen" if="$(arg hwil)"/>
+	<node pkg="can_to_ros" type="simple_mini_car_from_lead_distance" name="simple_mini_car_from_lead_distance" output="screen" if="$(arg hwil)"/>
+-->
+
+	<include file="$(find can_to_ros)/launch/vanilla_interface.launch"/>
+
+<!--
+	<node pkg="can_to_ros" type="vehicle_interface_nissan" name="vehicle_interface_nissan" output="screen"/>
+	<node pkg="can_to_ros" type="subs" name="subs" output="screen" />
+	<node pkg="can_to_ros" type ="rosbag_record.sh" name="bashscript2" output="screen" args="$(arg description) $(arg hwil)" /> 
+-->
+	<param name="model" type="string" value="$(find onnx2ros)/../controllers/RL-cruise-hybrid/rl_acc_blind_sp/model.onnx"/>
+	<param name="mode" type="string" value="prompt"/>
+	<node pkg="onnx2ros" type="prompt_mode" name="controller" output="screen"/>
+
+
+</launch>

--- a/launch/rl_cruise_hybrid_planner_readonly.launch
+++ b/launch/rl_cruise_hybrid_planner_readonly.launch
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<launch>
+
+	<arg name="description" default="rl_cruise_hybrid_planner"/>
+	
+	<arg name="hwil" default="true"/>
+	<arg name="SPACEGAP_SCALE" default="100.0"/>
+	<arg name="SPEED_SCALE" default="40.0"/>
+	<!-- for planner, set these two to positive values -->
+	<arg name="SP_TARGET_SPEED" default="70"/>
+	<arg name="SP_MAX_HEADWAY" default="1"/>
+	<arg name='readonly' default='true'/>
+
+	<param name="description" value="$(arg description)"/>
+		
+	<param name="/SPACEGAP_SCALE" value="$(arg SPACEGAP_SCALE)"/>
+	<param name="/SPEED_SCALE" value="$(arg SPEED_SCALE)"/>
+	<param name="/SP_TARGET_SPEED" value="$(arg SP_TARGET_SPEED)"/>
+	<param name="/SP_MAX_HEADWAY" value="$(arg SP_MAX_HEADWAY)"/>
+	
+	<param name="/readonly" value="$(arg readonly)"/>
+	<param name="/hwil" value="$(arg hwil)"/>
+<!--
+	<node pkg="can_to_ros" type ="subs_fs" name="subs_fs" output="screen" if="$(arg hwil)"/> 
+	<node pkg="can_to_ros" type="lead_info" name="lead_info" output="screen" if="$(arg hwil)"/>
+	<node pkg="can_to_ros" type="simple_mini_car_from_lead_distance" name="simple_mini_car_from_lead_distance" output="screen" if="$(arg hwil)"/>
+-->
+        <include file="$(find can_to_ros)/launch/vanilla_interface.launch"/>
+
+<!--
+	<node pkg="can_to_ros" type="vehicle_interface_nissan" name="vehicle_interface_nissan" output="screen" />
+	<node pkg="can_to_ros" type="subs_fs_test" name="subs_fs_test" output="screen" />
+	<node pkg="can_to_ros" type ="rosbag_record.sh" name="bashscript2" output="screen" args="$(arg description) $(arg hwil)" /> 
+-->
+
+	<param name="model" type="string" value="$(find onnx2ros)/../controllers/RL-cruise-hybrid/rl_acc_blind_sp/model.onnx"/>
+	<param name="mode" type="string" value="prompt"/>
+	<node pkg="onnx2ros" type="prompt_mode" name="controller" output="screen"/>
+
+
+</launch>


### PR DESCRIPTION
I just copied the `rl_cruise_planner_readonly.launch` and `rl_cruise_noplanner_readonly.launch` into new files and changed the ONNX files and description. Is that all I need to do?